### PR TITLE
Style filters like Excel segments

### DIFF
--- a/filtres.css
+++ b/filtres.css
@@ -92,10 +92,10 @@
 }
 
 .filtre-item-selectionne {
-    background-color: #dc3545;
-    border-color: #dc3545;
+    background-color: #0078d4;
+    border-color: #0078d4;
     color: #fff;
-    font-weight: 500;
+    font-weight: 600;
 }
 
 .filtre-item input[type="checkbox"] {
@@ -135,16 +135,24 @@
     animation: slideDown 0.2s ease-out;
 }
 
-/* Style pour les valeurs en surbrillance */
+/* Style pour les valeurs disponibles */
 .valeur-disponible {
     font-weight: 600;
-    color: #198754; /* Vert de succès */
+}
+
+/* Style pour les valeurs indisponibles */
+.valeur-indisponible {
+    color: #a6a6a6;
+    background-color: #f0f0f0;
+    border-color: #d9d9d9;
+    cursor: not-allowed;
+    pointer-events: none;
 }
 
 /* Style pour les filtres actifs */
 .filtre-actif {
-    border-color: #004494; /* Bleu Principal CDC Habitat */
-    box-shadow: 0 0 0 1px #004494;
+    border-color: #0078d4;
+    box-shadow: 0 0 0 1px #0078d4;
 }
 
 /* Style pour les écrans mobiles */

--- a/filtres.js
+++ b/filtres.js
@@ -311,12 +311,15 @@ class Filtres {
 
             if (disponibles.has(valeur)) {
                 item.classList.add('valeur-disponible');
+                item.addEventListener('click', () => this.basculerSelection(filtre, valeur, item));
+            } else {
+                item.classList.add('valeur-indisponible');
+                item.style.pointerEvents = 'none';
             }
             if (this.filtresActifs[filtre.id] && this.filtresActifs[filtre.id].has(valeur)) {
                 item.classList.add('filtre-item-selectionne');
             }
 
-            item.addEventListener('click', () => this.basculerSelection(filtre, valeur, item));
             liste.appendChild(item);
         });
         


### PR DESCRIPTION
## Summary
- Disable selection for unavailable filter values and visually distinguish them
- Update selected filter styling to blue to resemble Excel segments

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e28ea064832eaf4bf5a502a41e1e