### PR TITLE
Add clear filter icon

### DIFF
--- a/filtres.css
+++ b/filtres.css
@@ -45,6 +45,27 @@
     font-weight: 600;
 }
 
+.filtre-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.filtre-clear {
+    display: none;
+    background: none;
+    border: none;
+    color: #004494; /* Bleu Principal CDC Habitat */
+    cursor: pointer;
+    font-size: 0.9rem;
+    line-height: 1;
+    padding: 0;
+}
+
+.filtre-clear:hover {
+    color: #dc3545;
+}
+
 .filtre-contenu {
     display: none;
     max-height: 300px;
@@ -100,29 +121,6 @@
 
 .filtre-item input[type="checkbox"] {
     margin-right: 0.5rem;
-}
-
-.filtre-actions {
-    display: flex;
-    justify-content: space-between;
-    padding: 0.5rem 0.75rem;
-    border-top: 1px solid #E6E6E6;
-    background-color: #F8F9FA;
-}
-
-.filtre-btn {
-    background: none;
-    border: none;
-    color: #004494; /* Bleu Principal CDC Habitat */
-    cursor: pointer;
-    font-size: 0.8rem;
-    padding: 0.25rem 0.5rem;
-    border-radius: 3px;
-    transition: background-color 0.2s;
-}
-
-.filtre-btn:hover {
-    background-color: #E6F2F9; /* Bleu Clair CDC Habitat */
 }
 
 /* Animation pour l'ouverture/fermeture */

--- a/filtres.js
+++ b/filtres.js
@@ -230,9 +230,24 @@ class Filtres {
         const badge = document.createElement('span');
         badge.className = 'filtre-badge';
         badge.textContent = '0';
-        
+
+        const clearBtn = document.createElement('button');
+        clearBtn.className = 'filtre-clear';
+        clearBtn.innerHTML = '&times;';
+        clearBtn.title = 'Réinitialiser';
+        clearBtn.style.display = 'none';
+        clearBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.effacerFiltre(filtre);
+        });
+
+        const actionsHeader = document.createElement('div');
+        actionsHeader.className = 'filtre-header-actions';
+        actionsHeader.appendChild(badge);
+        actionsHeader.appendChild(clearBtn);
+
         header.appendChild(titre);
-        header.appendChild(badge);
+        header.appendChild(actionsHeader);
         
         // Contenu du filtre
         const contenu = document.createElement('div');
@@ -254,28 +269,10 @@ class Filtres {
         const liste = document.createElement('ul');
         liste.className = 'filtre-liste';
         contenu.appendChild(liste);
-        
-        // Actions du filtre
-        const actions = document.createElement('div');
-        actions.className = 'filtre-actions';
-        
-        const btnEffacer = document.createElement('button');
-        btnEffacer.className = 'filtre-btn';
-        btnEffacer.textContent = 'Effacer';
-        btnEffacer.addEventListener('click', () => this.effacerFiltre(filtre));
-        
-        const btnFermer = document.createElement('button');
-        btnFermer.className = 'filtre-btn';
-        btnFermer.textContent = 'Fermer';
-        btnFermer.addEventListener('click', () => this.basculerFiltre(filtreElement));
-        
-        actions.appendChild(btnEffacer);
-        actions.appendChild(btnFermer);
-        
+
         // Assemblage des éléments
         filtreElement.appendChild(header);
         filtreElement.appendChild(contenu);
-        filtreElement.appendChild(actions);
         
         // Gestionnaire d'événements pour l'en-tête
         header.addEventListener('click', () => this.basculerFiltre(filtreElement));
@@ -325,7 +322,12 @@ class Filtres {
         if (badge) {
             const nbSelectionnes = this.filtresActifs[filtre.id] ? this.filtresActifs[filtre.id].size : 0;
             badge.textContent = nbSelectionnes;
-            
+
+            const clearBtn = filtreElement.querySelector('.filtre-clear');
+            if (clearBtn) {
+                clearBtn.style.display = nbSelectionnes > 0 ? 'inline-flex' : 'none';
+            }
+
             // Mettre à jour l'état actif du filtre
             if (nbSelectionnes > 0) {
                 filtreElement.classList.add('filtre-actif');


### PR DESCRIPTION
## Summary
- replace text-based Effacer/Fermer controls with a compact clear icon in each filter header
- style and hide/show new clear button for active filters

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898e27874f0832e8c14513ba669ed77