### PR TITLE
Improve filter availability highlighting

### DIFF
--- a/filtres.css
+++ b/filtres.css
@@ -141,6 +141,12 @@
     color: #198754; /* Vert de succès */
 }
 
+.valeur-indisponible {
+    color: #6c757d; /* Gris pour indisponible */
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
 /* Style pour les filtres actifs */
 .filtre-actif {
     border-color: #004494; /* Bleu Principal CDC Habitat */

--- a/filtres.js
+++ b/filtres.js
@@ -309,14 +309,23 @@ class Filtres {
             item.className = 'filtre-item';
             item.textContent = valeur;
 
-            if (disponibles.has(valeur)) {
-                item.classList.add('valeur-disponible');
-            }
-            if (this.filtresActifs[filtre.id] && this.filtresActifs[filtre.id].has(valeur)) {
+            const estSelectionne = this.filtresActifs[filtre.id] && this.filtresActifs[filtre.id].has(valeur);
+            const estDisponible = disponibles.has(valeur);
+
+            if (estSelectionne) {
                 item.classList.add('filtre-item-selectionne');
             }
 
-            item.addEventListener('click', () => this.basculerSelection(filtre, valeur, item));
+            if (estDisponible) {
+                item.classList.add('valeur-disponible');
+            } else if (!estSelectionne) {
+                item.classList.add('valeur-indisponible');
+            }
+
+            if (estDisponible || estSelectionne) {
+                item.addEventListener('click', () => this.basculerSelection(filtre, valeur, item));
+            }
+
             liste.appendChild(item);
         });
         

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
             
             // Ajouter les données directement depuis bdd
             filtres.add_data(bdd);
+            const donnees = filtres.data;
             
             // Ajouter des filtres
             filtres.add_filtre('clef', 'clef', {


### PR DESCRIPTION
## Summary
- Add missing data reference in dashboard initialization
- Mark unavailable filter values and disable their selection
- Style unavailable filter entries in grey

## Testing
- `node --check filtres.js`


------
https://chatgpt.com/codex/tasks/task_e_6898e2e13854832eb49bf8b4251433f3